### PR TITLE
Added blocking sleeps on the purchasing evals to not miss price ticks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,5 +84,4 @@ celerybeat*
 
 *.sw*
 
-aliyun/
-search.txt
+logs.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ playwright==1.19.1
 pyee==8.1.0
 PySimpleGUI==4.57.0
 websockets==10.1
+uvloop==0.16.0

--- a/ses.py
+++ b/ses.py
@@ -21,7 +21,7 @@ if __name__ == '__main__'
         print('The page is taking long to load please wait')
         sleep(10)
 
-    sleep(5)
+    sleep(8)
     spot_balance_span = page.locator("#spot")
     stake_input = page.locator("#amount")
 
@@ -30,37 +30,30 @@ if __name__ == '__main__'
 
 
     while True:
-        bid_spot = await spot_balance_span.inner_text()
-        if bid_spot:
-            while prev_spot == bid_spot:
-                bid_spot = await spot_balance_span.inner_text()
+        bid_spot = spot_balance_span.inner_text()
 
-            bid_ldp = int(bid_spot[-1])
+        bid_ldp = int(bid_spot[-1])
 
-        if bid_ldp is self.ldp: #Play Check
+        if bid_ldp is 8: #Play Check
             #Once LDP is correct, purchase immediately,
             #Deriv will schedule for the next price spot
-            await self.page.locator("#purchase_button_top").click()
+            page.locator("#purchase_button_top").click()
 
             #Sleep will facilitate Waiting for the price to change
             #Then we can move on to check if we won or fail
-            await asyncio.sleep(0.8)
+            #See https://github.com/microsoft/playwright/issues/4051
 
-            next_price = await spot_balance_span.inner_text()
+            await self.page.evaluate("""() => {
+                  new window.MutationObserver((mutations) => {
+                      if (mutation.addedNodes.length) {
+                        return;
+                      }
+                  }).observe(document.getElementById('spot'), { childList: true });
+            }""")
+
+            next_price 
             #If the price spot didn't change yet
             #try again to read the next_price
-            while next_price == bid_spot:
-                next_price = await spot_balance_span.inner_text()
-
-            bl = await self.page.locator("#header__acc-balance").inner_text()
-            if bl:
-                cur_balance = float(bl.split()[0].replace(',',''))
-
-                stop_est = cur_balance - self.start_balance
-
-                if stop_est > float(self.stop_profit) or abs(stop_est) > float(self.stop_loss):
-                    self.loop = False
-                    return 'AS'
 
             print(bid_spot, next_price, next_price[-1])
 

--- a/ses.py
+++ b/ses.py
@@ -1,0 +1,96 @@
+#Fixing the session file:
+#The ticking monitor
+from time import sleep
+from playwright.sync_api import sync_playwright
+
+if __name__ == '__main__'
+    playwright = sync_playwright().start()
+    browser = playwright.chromium.launch(headless=False)
+
+    state = "state.json"
+    context =  browser.new_context(storage_state=state)
+    page =  context.new_page()
+
+    try:
+        page.goto(
+            "https://smarttrader.deriv.com/en/trading.html?currency=USD&market=synthetic_index&underlying=R_100&formname=matchdiff&date_start=now&duration_amount=1&duration_units=t&amount=0.35&amount_type=stake&expiry_type=duration&prediction=8"
+        )
+
+    except PWTimeoutError as e:
+        #traceback.format_exc()
+        print('The page is taking long to load please wait')
+        sleep(10)
+
+    sleep(5)
+    spot_balance_span = page.locator("#spot")
+    stake_input = page.locator("#amount")
+
+    #The use of handle is discouraged. But useful to check if element is_visible()
+    purchase_handle = page.wait_for_selector('#purchase_button_top')
+
+
+    while True:
+        bid_spot = await spot_balance_span.inner_text()
+        if bid_spot:
+            while prev_spot == bid_spot:
+                bid_spot = await spot_balance_span.inner_text()
+
+            bid_ldp = int(bid_spot[-1])
+
+        if bid_ldp is self.ldp: #Play Check
+            #Once LDP is correct, purchase immediately,
+            #Deriv will schedule for the next price spot
+            await self.page.locator("#purchase_button_top").click()
+
+            #Sleep will facilitate Waiting for the price to change
+            #Then we can move on to check if we won or fail
+            await asyncio.sleep(0.8)
+
+            next_price = await spot_balance_span.inner_text()
+            #If the price spot didn't change yet
+            #try again to read the next_price
+            while next_price == bid_spot:
+                next_price = await spot_balance_span.inner_text()
+
+            bl = await self.page.locator("#header__acc-balance").inner_text()
+            if bl:
+                cur_balance = float(bl.split()[0].replace(',',''))
+
+                stop_est = cur_balance - self.start_balance
+
+                if stop_est > float(self.stop_profit) or abs(stop_est) > float(self.stop_loss):
+                    self.loop = False
+                    return 'AS'
+
+            print(bid_spot, next_price, next_price[-1])
+
+            if int(next_price[-1]) is bid_ldp:
+                print('--WON--')
+                self.stake = self.init_stake
+            else:
+                print('LOST!!!')
+                self.stake = round(self.stake * self.mtng + self.stake, 2)
+
+            print(f'The stake is updated to: {self.stake}')
+            await asyncio.sleep(0.8)
+            await stake_input.fill(str(self.stake))
+
+            pbtn_visible = await purchase_handle.is_visible()
+            if not pbtn_visible:
+                try:
+                    await self.page.locator("#close_confirmation_container").click()
+                except PWTimeoutError as e:
+                    print('Purchase button is disabled by Deriv, waiting for activation to play...')
+                    await asyncio.sleep(6)
+                    return await self.tight_play(spot_balance_span, stake_input, purchase_handle)
+
+            prev_spot = next_price
+        else:
+            #Wait for the tick spot price to change first
+            #Before moving to the next loop round
+            prev_spot = bid_spot
+            await asyncio.sleep(0.8)
+
+        #prev_spot = bid_spot
+        await asyncio.sleep(0)
+

--- a/session.py
+++ b/session.py
@@ -146,7 +146,7 @@ class TradeSession:
                 try:
                     await self.page.locator("#purchase_button_top").click(timeout=100)
 
-                    print(f'PLAYING STAKE IS: {self.stake}')
+                    sleep(0.2)
                     bid_spot_purchase = await spot_balance_span.inner_text()
 
                     next_price = await spot_balance_span.inner_text()
@@ -192,10 +192,7 @@ class TradeSession:
 
                     pbtn_visible = await self.purchase_handle.is_visible()
                     if not pbtn_visible:
-                        await self.page.locator(
-                                "#close_confirmation_container"
-                            ).click(timeout=20000)
-
+                        await self.close_btn_handle.click()
                     prev_spot = next_price
 
                 except PWTimeoutError as e:
@@ -223,6 +220,9 @@ class TradeSession:
         Runs the smarttrader session with Volatility 100,
         Match/Differ option and Tick = 1
         '''
+
+        window['_PLAY_STATUS_'].update('PLAYING...')
+
         if not values['_SK_'] or not values['_MG_'] or not values['_LDP_']:
             window['_MESSAGE_'].update(
                     'Please provide LDP, Stake and initial Martingale'
@@ -231,6 +231,12 @@ class TradeSession:
 
         if self.paused:
             self.paused = False
+            xbtn_visible = await self.close_btn_handle.is_visible()
+            if xbtn_visible:
+                try:
+                    await self.close_btn_handle.click(timeout=2000)
+                except PWTimeoutError as e:
+                    pass
         else:
             #New Play session, take stake value from the user input
             self.stake = self.init_stake = float(values['_SK_'])
@@ -240,7 +246,6 @@ class TradeSession:
         self.stop_profit = float(values['_SP_'])
         self.ldp = int(values['_LDP_'])
 
-        window['_PLAY_STATUS_'].update('PLAYING...')
         spot_balance_span = self.page.locator("#spot")
         stake_input = self.page.locator("#amount")
 
@@ -278,9 +283,7 @@ class TradeSession:
         xbtn_visible = await self.close_btn_handle.is_visible()
         if xbtn_visible:
             try:
-                await self.page.locator(
-                        "#close_confirmation_container"
-                    ).click(timeout=3000)
+                await self.close_btn_handle.click(timeout=2000)
             except PWTimeoutError as e:
                 pass
 

--- a/session.py
+++ b/session.py
@@ -134,6 +134,13 @@ class TradeSession:
         bid_spot = prev_spot = ''
         self.loop = True
 
+        xbtn_visible = await self.close_btn_handle.is_visible()
+        if xbtn_visible:
+            try:
+                await self.close_btn_handle.click(timeout=5000)
+            except PWTimeoutError:
+                pass
+
         while self.loop:
             bid_spot = await spot_balance_span.inner_text()
 
@@ -146,7 +153,7 @@ class TradeSession:
                 try:
                     await self.page.locator("#purchase_button_top").click(timeout=100)
 
-                    sleep(0.2)
+                    sleep(0.6)
                     bid_spot_purchase = await spot_balance_span.inner_text()
 
                     next_price = await spot_balance_span.inner_text()

--- a/session.py
+++ b/session.py
@@ -144,13 +144,10 @@ class TradeSession:
                 #Once LDP is correct, purchase immediately,
                 #Deriv will schedule for the next price spot
                 try:
-                    await self.page.locator("#purchase_button_top").click(timeout=3000)
+                    await self.page.locator("#purchase_button_top").click(timeout=100)
 
                     print(f'PLAYING STAKE IS: {self.stake}')
                     bid_spot_purchase = await spot_balance_span.inner_text()
-                    #Sleep will facilitate Waiting for the price to change
-                    #Then we can move on to check if we won or fail
-                    sleep(0.1)
 
                     next_price = await spot_balance_span.inner_text()
                     #If the price spot didn't change yet
@@ -167,10 +164,9 @@ class TradeSession:
                         else:
                             print('FAST LOST!!!')
                             self.stake = round(self.stake * self.mtng + self.stake, 2)
-
                     else:
                         #This sleep is to wait for the results,
-                        #don't give access to event loop
+                        #don't give control back to the event loop
                         sleep(0.5)
                         result_str = await self.page.locator(
                                 "#contract_purchase_heading"
@@ -198,14 +194,14 @@ class TradeSession:
                     if not pbtn_visible:
                         await self.page.locator(
                                 "#close_confirmation_container"
-                            ).click(timeout=3000)
+                            ).click(timeout=20000)
 
                     prev_spot = next_price
 
                 except PWTimeoutError as e:
                     print(e)
                     print('Purchase btn is disabled by Deriv, waiting for activation...')
-                    await asyncio.sleep(6)
+                    await asyncio.sleep(5)
                     return await self.tight_play(spot_balance_span, stake_input)
 
             else:
@@ -274,7 +270,7 @@ class TradeSession:
         await asyncio.sleep(4)
         status = await self.tight_play(spot_balance_span, stake_input)
         if status == 'AS':
-            window['_PLAY_STATUS_'].update('AUTO STOPPED!')
+            window['_PLAY_STATUS_'].update('STOPPED!')
 
         elif status == 'BK':
             window['_PLAY_STATUS_'].update('PURCHASE BLOCKED!')

--- a/trade.py
+++ b/trade.py
@@ -95,7 +95,7 @@ async def main(window, trade_session):
 
 
 if __name__ == '__main__':
-    sg.theme('BluePurple')
+    sg.theme('DarkAmber')
 
     layout = [
         [sg.Text(size=(30,1), key='_MESSAGE_')],

--- a/trade.py
+++ b/trade.py
@@ -1,6 +1,7 @@
 import asyncio
 import secrets
 import traceback
+import uvloop
 import PySimpleGUI as sg
 from session import TradeSession
 
@@ -142,6 +143,7 @@ if __name__ == '__main__':
     trade_session = TradeSession()
 
     try:
+        uvloop.install()
         asyncio.run(main(window, trade_session))
     except Exception as e:
         print(traceback.format_exc())

--- a/trade.py
+++ b/trade.py
@@ -142,5 +142,5 @@ if __name__ == '__main__':
     try:
         asyncio.run(main(window, trade_session))
     except Exception as e:
-        #print(traceback.format_exc())
+        print(traceback.format_exc())
         print('The program has been halted!')

--- a/trade.py
+++ b/trade.py
@@ -49,7 +49,7 @@ async def bg(window, trade_session):
 
     while True:
         await asyncio.sleep(0)
-        event, values = window.read(timeout=5)
+        event, values = window.read(timeout=0)
 
         action = await event_listeners(event, values, window, trade_session)
         if action == 'BR':
@@ -66,7 +66,7 @@ async def ui(window, trade_session):
     '''
     while True:  # PysimpleGUI Event Loop
         await asyncio.sleep(0)
-        event, values = window.read(timeout=5)
+        event, values = window.read(timeout=0)
 
         if event == '_BUTTON_PLAY_':
             await trade_session.play(


### PR DESCRIPTION
There is still a reported issue that sometimes when the bot wins the purchase, the stake is sadly not reset back to the initial value. I have found out sometimes the price ticks are too fast and the bot misses the next price, sometimes it misses 2, 3 rounds which is insane. 

A perfect fix is to stop relying on sleeps and to rather evaluate the JS Mutation observer instance on PW. I couldn't get this to work last time, but for now, I've first tried to reduce the parameter value of sleeps to .2 secs, and if possible I'll just remove them and let the while loop evaluate if the price tick has completed.

